### PR TITLE
Upgraded dependencies to align with newer releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient-cache</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.3</version>
 		</dependency>
 
 		<!-- core functions -->
@@ -85,13 +85,13 @@
 		<dependency>
 			<groupId>com.thoughtworks.xstream</groupId>
 			<artifactId>xstream</artifactId>
-			<version>1.4.9</version>
+			<version>1.4.10</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.0</version>
+			<version>2.8.2</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Hi - I just took time to upgraded a few dependencies that were too old and had more mature releases. Some of the dependencies still have a newer version but they are either beta or for specific Java edition which may break backward compatibility.